### PR TITLE
feat: show focus outline on team names

### DIFF
--- a/public/jeopardy.css
+++ b/public/jeopardy.css
@@ -55,7 +55,8 @@
     .scoreboard{ display:flex; gap:12px; flex-wrap:wrap; align-items:stretch }
     .team{ background:var(--card); border:1px solid rgba(255,255,255,.08); border-radius:var(--radius); padding:12px; min-width:200px; box-shadow:var(--shadow); display:grid; gap:10px; align-content:start }
     .team header{position:unset; background:transparent; padding:0; border:none}
-    .team-name{ font-weight:800; font-size:18px; outline:none; border:none; width:100%; color:var(--text); background:transparent; border-bottom:1px dashed rgba(255,255,255,.18); padding-bottom:4px }
+    .team-name{ font-weight:800; font-size:18px; border:none; width:100%; color:var(--text); background:transparent; border-bottom:1px dashed rgba(255,255,255,.18); padding-bottom:4px }
+    .team-name:focus{ outline:2px solid var(--accent); }
     .score{font-size:28px; font-weight:900}
     .score-controls{display:flex; gap:8px; flex-wrap:wrap}
     .score-controls input{width:90px; background:#0e1735; color:var(--text); border:1px solid rgba(255,255,255,.12); border-radius:8px; padding:8px}


### PR DESCRIPTION
## Summary
- remove outline suppression on team name fields
- add explicit focus outline using accent color

## Testing
- `npm test` (fails: Error: no test specified)
- `node -e <script>` manual tab navigation confirms 2px accent outline

------
https://chatgpt.com/codex/tasks/task_e_689cccf6cc78832bb5ae2c6a03f23a96